### PR TITLE
[code-review] HttpFoundation\Request в контроллере

### DIFF
--- a/src/Controller/TelegramController.php
+++ b/src/Controller/TelegramController.php
@@ -15,6 +15,7 @@ use App\Service\TelegramDb;
 use App\Service\TelegramAPI;
 use App\Service\TelegramResponse;
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Component\DependencyInjection\ContainerInterface as Container;
@@ -52,7 +53,6 @@ class TelegramController extends Controller
 
         $this->tgBot = new TelegramAPI($this->tgToken, [$proxyName, $proxyPort, $proxyLogPass]);
         $this->tgResponse = new TelegramResponse;
-        $this->tgResponse->setResponseData(json_decode(file_get_contents('php://input'), true));
         $this->tgDb = new TelegramDb($container, $this->tgBot, $this->tgResponse);
 
         $this->bitrix24 = new Bitrix24API($container);
@@ -76,10 +76,13 @@ class TelegramController extends Controller
 
     /**
      * @Route("/tgWebhook", name="tg_webhook")
+     * @param Request $request
      * @return Response
      */
-    public function tgWebhook()
+    public function tgWebhook(Request $request)
     {
+        $this->tgResponse->setResponseData(json_decode($request->getContent(), true));
+
         // Если это известный нам ответ от телеграма
         if ($this->tgResponse->getResponseType()) {
             // Если пользователь найден, то не предлагаем ему регистрацию.

--- a/src/Controller/TelegramController.php
+++ b/src/Controller/TelegramController.php
@@ -178,7 +178,7 @@ class TelegramController extends Controller
             $this->tgBot->replyKeyboardMarkup($this->tgGlobalCommands, true)
         );
 
-        exit();
+        return new Response();
     }
 
     // Обнуляем введенные пользовательские данные
@@ -218,7 +218,7 @@ class TelegramController extends Controller
                 $this->tgBot->replyKeyboardMarkup($keyboard, true, false)
             );
 
-            exit();
+            return new Response();
         }
 
         if ($stage == "registration") {
@@ -241,7 +241,7 @@ class TelegramController extends Controller
                             "\u{26A0} Регистрация отклонена! *Номер найден*, но необходимо обязательно указать Email в bitrix24 для получения уведомлений!",
                             "Markdown"
                         );
-                        exit();
+                        return new Response();
                     }
                 }
             }
@@ -263,7 +263,7 @@ class TelegramController extends Controller
                 );
             }
 
-            exit();
+            return new Response();
         }
     }
 
@@ -278,7 +278,7 @@ class TelegramController extends Controller
                 $this->tgResponse->getText() == "/start") {
                 $this->commandHelp();
 
-                exit();
+                return new Response();
             }
 
             if ($this->tgResponse->getText() == "/mr" ||
@@ -286,7 +286,7 @@ class TelegramController extends Controller
                 // meetingRoomSelect при true обнуляет все пользовательские вводы и отображает заново список переговорок
                 $this->meetingRoomSelect(true);
 
-                exit();
+                return new Response();
                 // Обнуляем пользовательский ввод.
                 // Будет дополняться по мере добавления других нововведений (помимо переговорки)
             }
@@ -296,7 +296,7 @@ class TelegramController extends Controller
                 // meetingRoomSelect при true обнуляет все пользовательские вводы и отображает заново список переговорок
                 $this->userMeetingRoomList();
 
-                exit();
+                return new Response();
                 // Обнуляем пользовательский ввод.
                 // Будет дополняться по мере добавления других нововведений (помимо переговорки)
             }
@@ -304,7 +304,7 @@ class TelegramController extends Controller
 
             if ($this->tgResponse->getText() == "/ce") {
                 $this->cancelEvent();
-                exit();
+                return new Response();
             }
 
 
@@ -312,7 +312,7 @@ class TelegramController extends Controller
                 $this->tgResponse->getText() == "\u{1F680} Завершить сеанс") {
                 $this->commandCancel(true);
 
-                exit();
+                return new Response();
             }
 
             /*
@@ -330,16 +330,16 @@ class TelegramController extends Controller
                         $this->tgResponse->getChatId(),
                         "Необходимо выбрать дату!"
                     );
-                    exit();
+                    return new Response();
                 } elseif (!$meetingRoomUser->getTime()) {
                     $this->meetingRoomSelectedTime();
-                    exit();
+                    return new Response();
                 } elseif (!$meetingRoomUser->getEventName()) {
                     $this->meetingRoomSelectEventName();
-                    exit();
+                    return new Response();
                 } elseif (!$meetingRoomUser->getEventMembers()) {
                     $this->meetingRoomSelectEventMembers();
-                    exit();
+                    return new Response();
                 }
             }
             /*
@@ -379,14 +379,14 @@ class TelegramController extends Controller
                 "Доступны только даты в промежутке *[{$this->calendar->getDate()}-{$this->calendar->getDate(-$this->dateRange)}]*",
                 "Markdown"
             );
-            exit();
+            return new Response();
         }
 
         if (isset($data["event"]["calendar"])) {
 
             if ($data["event"]["calendar"] == "selectDay") {
                 $this->meetingRoomSelectTime($data);
-                exit();
+                return new Response();
             }
 
             if ($data["event"]["calendar"] == "previous" ||
@@ -405,7 +405,7 @@ class TelegramController extends Controller
                         break;
                 }
                 $this->meetingRoomSelectDate($keyboard);
-                exit();
+                return new Response();
             }
         }
 
@@ -414,17 +414,17 @@ class TelegramController extends Controller
                 $this->meetingRoomSelectEventMembers($data);
             }
 
-            exit();
+            return new Response();
         }
 
         if (isset($data["event"]["confirm"])) {
             $this->meetingRoomConfirm($data);
 
-            exit();
+            return new Response();
         }
 
         if (isset($data["empty"]))
-            exit();
+            return new Response();
     }
 
     public function meetingRoomSelect($switch = false)
@@ -810,7 +810,7 @@ class TelegramController extends Controller
                     false,
                     $this->tgBot->inlineKeyboardMarkup($keyboard)
                 );
-                exit();
+                return new Response();
             }
         }
     }
@@ -845,7 +845,7 @@ class TelegramController extends Controller
                         null,
                         "Markdown"
                     );
-                    exit();
+                    return new Response();
                 }
             } else {
                 $members = $this->membersList($meetingRoomUserData);
@@ -876,7 +876,7 @@ class TelegramController extends Controller
                     $this->tgBot->inlineKeyboardMarkup($keyboard)
                 );
 
-                exit();
+                return new Response();
             }
         }
     }
@@ -901,7 +901,7 @@ class TelegramController extends Controller
                         null,
                         "Markdown"
                     );
-                    exit();
+                    return new Response();
                 }
             }
 
@@ -933,7 +933,7 @@ class TelegramController extends Controller
                 $this->tgBot->inlineKeyboardMarkup($keyboard)
             );
 
-            exit();
+            return new Response();
         }
     }
 
@@ -1149,7 +1149,7 @@ class TelegramController extends Controller
             $this->tgBot->inlineKeyboardMarkup($keyboard)
         );
 
-        exit();
+        return new Response();
     }
 
     public function userMeetingRoomList()


### PR DESCRIPTION
Необходимо использовать HttpFoundation\Request для получения тела запроса в контроллере. Использование ресурса php://input неочевидно привязывает реализацию метода к внешнему контексту.

https://symfony.com/doc/4.1/controller.html#the-request-object-as-a-controller-argument